### PR TITLE
Bump compatibility version to V9

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
     "author": "Felipe Figueiredo",
     "version": "1.0.2",
     "minimumCoreVersion": "0.6.6",
-    "compatibleCoreVersion": "0.8.8",
+    "compatibleCoreVersion": "9",
     "url":"https://github.com/lipefl/sync-token-name",
     "manifest":"https://raw.githubusercontent.com/lipefl/sync-token-name/main/module.json",
     "download":"https://github.com/lipefl/sync-token-name/archive/main.zip",


### PR DESCRIPTION
This mod seems to be working fine in Foundry V9, there are also no tickets currently pending on it connected to v9. I suggest updating the compatibleCoreVersion to get rid of the Compatibility Risk warning